### PR TITLE
fix: add missing <cstdint> to audiobuffer.h / audiofile.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,4 +130,9 @@ target_link_libraries(sound_capture
     PRIVATE
         $<$<BOOL:${APPLE}>:${CORE_AUDIO_FRAMEWORK}>
         $<$<BOOL:${APPLE}>:${CORE_FOUNDATION_FRAMEWORK}>
+        # WASAPI uses KS audio format GUIDs (KSDATAFORMAT_SUBTYPE_*). MSVC
+        # auto-resolves them via #pragma comment(lib) in the SDK headers;
+        # MinGW doesn't, so the link must request ksuser explicitly. No-op
+        # on MSVC.
+        $<$<BOOL:${WIN32}>:ksuser>
 )

--- a/include/slk/audiobuffer.h
+++ b/include/slk/audiobuffer.h
@@ -18,6 +18,7 @@
 #include <vector>
 #include <cassert>
 #include <algorithm>
+#include <cstdint>
 
 namespace slk
 {

--- a/include/slk/audiofile.h
+++ b/include/slk/audiofile.h
@@ -19,6 +19,7 @@
 #include <slk/audiobuffer.h>
 #include <fstream>
 #include <span>
+#include <cstdint>
 
 namespace slk
 {


### PR DESCRIPTION
## Summary

Both `include/slk/audiobuffer.h` and `include/slk/audiofile.h` use `uint16_t` / `uint32_t` but neither `#include <cstdint>`. MSVC and most libstdc++ setups expose them transitively via other STL headers, which is why the existing CI never flagged it. Stricter toolchains do not.

## Why this matters now

Surfaced cross-compiling Draft's whisper client under MinGW GCC 14 on Linux:

```
include/slk/audiobuffer.h:34:23: error: 'uint32_t' does not name a type
include/slk/audiobuffer.h:21:1: note: 'uint32_t' is defined in header '<cstdint>'
```

Once `audiobuffer.h` fails its declarations, every downstream TU sees the `WAV::Header` struct missing all its `uintN_t`-typed members (`blocSize`, `audioFormat`, `numChannels`, …) — that's the cascade.

## Test plan

- [ ] CI green on `dev` (no behaviour change)
- [ ] Draft's MinGW Build-Windows-MinGW job on its CI advances past the audio_lib compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)